### PR TITLE
Add 'M2' device assertion

### DIFF
--- a/device_meilan2.mk
+++ b/device_meilan2.mk
@@ -13,7 +13,7 @@ else
 	LOCAL_KERNEL := $(TARGET_PREBUILT_KERNEL)
 endif
 
-TARGET_OTA_ASSERT_DEVICE := meilan2,meizu_m2_mini,m2
+TARGET_OTA_ASSERT_DEVICE := meilan2,meizu_m2_mini,m2,M2
 
 TARGET_PROVIDES_INIT_RC := true
 


### PR DESCRIPTION
Just had this case problem to flash this rom on a Meizu M2 (mini). The device was identified as "M2" and not "m2".
Not sure if it's the right file to edit to fix the problem as I don't have the required env to build and test it.
Anyway to fix my problem I had to edit this file in the zip: "./META-INF/com/google/android/updater-script".
